### PR TITLE
replace slack with discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ pipenv run python -m pytest
 
 ## Stay in touch
 
-Join our [Slack channel](https://foxglove.dev/slack) to ask questions, share feedback, and stay up to date on what our team is working on.
+Join our [Discord](https://foxglove.dev/chat) to ask questions, share feedback, and stay up to date on what our team is working on.


### PR DESCRIPTION
### Changelog

None

### Docs

None

### Description

Replace the Slack link in the README with a link to our Discord.