### PR TITLE
Update "fetching_messages" example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - run: pipenv run black --check --diff --color --exclude '.*_pb2.py' .
       - run: pipenv run pyright foxglove
       - run: pipenv run python -m flake8 foxglove
+      - run: pipenv run python -m flake8 examples
       - run: pipenv run python -m pytest
       - run: pipenv run python -m build
 

--- a/examples/downloading_data.py
+++ b/examples/downloading_data.py
@@ -1,4 +1,3 @@
-import datetime
 from datetime import datetime, timedelta
 
 from foxglove.client import Client

--- a/examples/fetching_messages.py
+++ b/examples/fetching_messages.py
@@ -1,4 +1,3 @@
-import datetime
 from datetime import datetime, timedelta
 
 from foxglove.client import Client

--- a/examples/fetching_messages.py
+++ b/examples/fetching_messages.py
@@ -9,10 +9,9 @@ client = Client(token=token)
 
 # Make sure you've imported either the mcap-ros1-support or mcap-protobuf-support
 # libraries before making this call in order to get decoded messages.
-messages = client.get_messages(
+for schema, channel, message, decoded_message in client.iter_messages(
     device_id=device_id,
     start=datetime.now() - timedelta(hours=3),
     end=datetime.now() - timedelta(hours=1),
-)
-
-print(f"downloaded {len(messages)} messages")
+):
+    print(f"[{message.log_time}] Channel: {channel.topic} Schema: {schema.name}")

--- a/examples/fetching_messages.py
+++ b/examples/fetching_messages.py
@@ -14,4 +14,4 @@ for schema, channel, message, decoded_message in client.iter_messages(
     start=datetime.now() - timedelta(hours=3),
     end=datetime.now() - timedelta(hours=1),
 ):
-    print(f"[{message.log_time}] Channel: {channel.topic} Schema: {schema.name}")
+    print(f"{message.log_time} | {channel.topic:<24} | {schema.name}")


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This updates the "fetching_messages" example to remove a deprecated method call in favor of the streaming `iter_messages`. Instead of printing the length, it prints the timestamp, channel, and topic of each message; for example:

```txt
1616425609698483083 | /gps/navheading          | sensor_msgs/Imu
1616425609700292327 | /gps/fix_velocity        | geometry_msgs/TwistWithCovarianceStamped
```