### PR TITLE
Use unstable publish action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
         if: |
           !github.event.pull_request.head.repo.fork &&
           startsWith(github.ref, 'refs/tags/releases/v')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@unstable/v1
         with:
           packages_dir: dist


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

Our most recent publish step failed: https://github.com/foxglove/foxglove-python/actions/runs/13660769163/job/38191137604

We appear to need this fix: https://github.com/pypa/gh-action-pypi-publish/pull/340 ...which is in [unstable/v1](https://github.com/pypa/gh-action-pypi-publish/commits/unstable/v1) but not yet in a versioned release.