### PR TITLE
Bump version to 0.15.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-client
-version = 0.15.4
+version = 0.15.5
 description = Client library for the Foxglove API.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
### Changelog

None.

### Docs

None

### Description

This is a re-release for the recording `key` change in 0.15.4, after a failed publish action (#118).
