### PR TITLE
Skip test attestations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
           github.actor != 'dependabot[bot]'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: dist
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          packages-dir: dist
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          attestations: false # https://github.com/pypa/gh-action-pypi-publish/issues/283#issuecomment-2499296440
 
       - name: Publish to PyPI
         if: |
@@ -43,4 +44,4 @@ jobs:
           startsWith(github.ref, 'refs/tags/releases/v')
         uses: pypa/gh-action-pypi-publish@unstable/v1
         with:
-          packages_dir: dist
+          packages-dir: dist


### PR DESCRIPTION
### Changelog
None
### Docs
None
### Description

This skips attestations when publishing to Test PyPI. Otherwise, with recent versions of the action, there will be conflicting attestations when we publish to [production] PyPI.

The underscore-dash changes match the documentation, but are normalized away in the action.