### PR TITLE
Bump version to 0.15.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = foxglove-client
-version = 0.15.5
+version = 0.15.6
 description = Client library for the Foxglove API.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
### Changelog

None.

### Docs

None

### Description

Re-release hopefully not subject to the duplicate attestations error (#120).