### PR TITLE
add project_id support

### DIFF
--- a/examples/uploading_data.py
+++ b/examples/uploading_data.py
@@ -34,3 +34,13 @@ client.upload_data(
     data=ros_data,
     callback=lambda size, progress: print(size, progress),
 )
+
+# Upload to a specific project
+project_id = "<YOUR PROJECT ID>"
+client.upload_data(
+    device_id=device_id,
+    filename="test upload to project",
+    data=mcap_data,
+    callback=lambda size, progress: print(size, progress),
+    project_id=project_id,
+)

--- a/foxglove/client.py
+++ b/foxglove/client.py
@@ -244,6 +244,7 @@ class Client:
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
         query: Optional[str] = None,
+        project_id: Optional[str] = None,
     ):
         """
         Retrieves events.
@@ -259,6 +260,7 @@ class Client:
         query: optional query string to filter events by metadata.
             See https://foxglove.dev/docs/api#tag/Events/paths/~1events/get for a syntax definition
             of `query`.
+        project_id: Optional Project to filter events by.
         """
         params = {
             "deviceId": device_id,
@@ -270,6 +272,7 @@ class Client:
             "start": start.astimezone().isoformat() if start else None,
             "end": end.astimezone().isoformat() if end else None,
             "query": query,
+            "projectId": project_id,
         }
         response = self.__session.get(
             self.__url__("/v1/events"),
@@ -475,6 +478,7 @@ class Client:
         device_id: Optional[str] = None,
         device_name: Optional[str] = None,
         tolerance: Optional[int] = None,
+        project_id: Optional[str] = None,
     ):
         """
         List coverage ranges for data.
@@ -484,6 +488,7 @@ class Client:
         :param device_id: Optional device id to limit data by.
         :param tolerance: Minimum interval (in seconds) that ranges must be separated by
             to be considered discrete.
+        :param project_id: Optional Project to filter coverage by.
         """
         params = {
             "deviceId": device_id,
@@ -491,6 +496,7 @@ class Client:
             "tolerance": tolerance,
             "start": start.astimezone().isoformat(),
             "end": end.astimezone().isoformat(),
+            "projectId": project_id,
         }
         response = self.__session.get(
             self.__url__("/v1/data/coverage"),
@@ -531,14 +537,18 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
+            "project_id": device["projectId"],
         }
 
-    def get_devices(self):
+    def get_devices(self, *, project_id: Optional[str] = None):
         """
         Returns a list of all devices.
+
+        :param project_id: Optional Project to filter devices by.
         """
         response = self.__session.get(
             self.__url__("/v1/devices"),
+            params=without_nulls({"projectId": project_id}),
         )
 
         json = json_or_raise(response)
@@ -548,6 +558,7 @@ class Client:
                 "id": d["id"],
                 "name": d["name"],
                 "properties": d["properties"] if "properties" in d else None,
+                "project_id": d["projectId"],
             }
             for d in json
         ]
@@ -557,6 +568,7 @@ class Client:
         *,
         name: str,
         properties: Optional[Dict[str, Union[str, bool, float, int]]] = None,
+        project_id: Optional[str] = None,
     ):
         """
         Creates a new device.
@@ -565,10 +577,17 @@ class Client:
         :param properties: Optional custom properties for the device.
             Each key must be defined as a custom property for your organization,
             and each value must be of the appropriate type
+        :param project_id: Project to create the device in. Required for multi-project organizations.
         """
         response = self.__session.post(
             self.__url__("/v1/devices"),
-            json=without_nulls({"name": name, "properties": properties}),
+            json=without_nulls(
+                {
+                    "name": name,
+                    "properties": properties,
+                    "projectId": project_id,
+                }
+            ),
         )
 
         device = json_or_raise(response)
@@ -577,6 +596,7 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
+            "project_id": device["projectId"],
         }
 
     def update_device(
@@ -613,6 +633,7 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
+            "project_id": device["projectId"],
         }
 
     def delete_device(
@@ -737,6 +758,7 @@ class Client:
         offset: Optional[int] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
+        project_id: Optional[str] = None,
     ):
         """Fetches recordings.
 
@@ -755,6 +777,7 @@ class Client:
         :param sort_order: Optionally specify the sort order, either "asc" or "desc".
         :param limit: Optionally limit the number of records returned.
         :param offset: Optionally offset the results by this many records.
+        :param project_id: Optional Project to filter recordings by.
         """
         all_params = {
             "deviceId": device_id,
@@ -769,6 +792,7 @@ class Client:
             "sortOrder": sort_order,
             "limit": limit,
             "offset": offset,
+            "projectId": project_id,
         }
         response = self.__session.get(
             self.__url__("/v1/recordings"),
@@ -797,6 +821,7 @@ class Client:
                     "device": i.get("device"),
                     "metadata": i.get("metadata"),
                     "key": i.get("key"),
+                    "project_id": i.get("projectId"),
                 }
             )
 
@@ -813,6 +838,7 @@ class Client:
         offset: Optional[int] = None,
         sort_by: Optional[str] = None,
         sort_order: Optional[str] = None,
+        project_id: Optional[str] = None,
     ):
         """List recording attachments.
 
@@ -825,6 +851,7 @@ class Client:
         :param sort_order: Optionally specify the sort order, either "asc" or "desc".
         :param limit: Optionally limit the number of records returned.
         :param offset: Optionally offset the results by this many records.
+        :param project_id: Optional Project to filter attachments by.
         """
         all_params = {
             "deviceId": device_id,
@@ -835,6 +862,7 @@ class Client:
             "sortOrder": sort_order,
             "limit": limit,
             "offset": offset,
+            "projectId": project_id,
         }
         response = self.__session.get(
             self.__url__("/v1/recording-attachments"),
@@ -883,7 +911,18 @@ class Client:
         start: datetime.datetime,
         end: datetime.datetime,
         include_schemas: bool = False,
+        project_id: Optional[str] = None,
     ):
+        """
+        List topics.
+
+        :param device_id: Optionally filter topics by this device ID.
+        :param device_name: Optionally filter topics by this device name.
+        :param start: Filter topics by this start time.
+        :param end: Filter topics by this end time.
+        :param include_schemas: Optionally include the schema in the response.
+        :param project_id: Optional Project to filter topics by.
+        """
         response = self.__session.get(
             self.__url__("/v1/data/topics"),
             params={
@@ -892,6 +931,7 @@ class Client:
                 "start": start.astimezone().isoformat(),
                 "end": end.astimezone().isoformat(),
                 "includeSchemas": "true" if include_schemas else "false",
+                "projectId": project_id,
             },
         )
 
@@ -920,6 +960,7 @@ class Client:
         filename: str,
         data: Union[bytes, IO[Any]],
         callback: Optional[SizeProgressCallback] = None,
+        project_id: Optional[str] = None,
     ):
         """
         Uploads data in bytes.
@@ -932,12 +973,14 @@ class Client:
             inferred from the file extension.
         data: The raw data in .bag or .mcap format.
         callback: An optional callback to report progress on the upload.
+        project_id: Optional Project to upload data to. Required for multi-project organizations if an existing device is not specified.
         """
         params = {
             "deviceId": device_id,
             "deviceName": device_name,
             "filename": filename,
             "key": key,
+            "projectId": project_id,
         }
         link_response = self.__session.post(
             self.__url__("/v1/data/upload"),

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -20,6 +20,7 @@ def test_get_attachments():
     fingerprint = fake.uuid4()
     site_id = fake.uuid4()
     now = datetime.now(tzoffset(None, 0))
+    project_id = "prj_123"
 
     responses.add(
         responses.GET,
@@ -38,11 +39,14 @@ def test_get_attachments():
                 "createTime": now.isoformat(),
             },
         ],
-        match=[responses.matchers.query_string_matcher("sortBy=logTime")],
+        match=[
+            responses.matchers.query_string_matcher("sortBy=logTime&projectId=prj_123"),
+        ],
     )
     client = Client("test")
     attachments = client.get_attachments(
         sort_by="log_time",
+        project_id=project_id,
     )
     assert attachments == [
         {

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -13,6 +13,7 @@ fake = Faker()
 def test_get_coverage():
     device_id = fake.uuid4()
     device_name = fake.name()
+    project_id = "prj_123"
     responses.add(
         responses.GET,
         api_url(f"/v1/data/coverage"),
@@ -22,18 +23,23 @@ def test_get_coverage():
                 "device": {"id": device_id, "name": device_name},
                 "start": datetime.now().isoformat(),
                 "end": datetime.now().isoformat(),
+                "projectId": project_id,
             },
             {
                 "deviceId": device_id,
                 "device": {"id": device_id, "name": device_name},
                 "start": datetime.now().isoformat(),
                 "end": datetime.now().isoformat(),
+                "projectId": project_id,
             },
         ],
     )
     client = Client("test")
     coverage = client.get_coverage(
-        start=datetime.now(), end=datetime.now(), device_id=device_id
+        start=datetime.now(),
+        end=datetime.now(),
+        device_id=device_id,
+        project_id=project_id,
     )
     assert len(coverage) == 2
     assert coverage[0]["device_id"] == device_id

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -72,9 +72,10 @@ def test_get_events():
     start = datetime.datetime.now().astimezone()
     end = start + datetime.timedelta(seconds=10)
     now = datetime.datetime.now().astimezone()
+    project_id = "prj_123"
     responses.add(
         responses.GET,
-        api_url(f"/v1/events?deviceId={device_id}"),
+        api_url(f"/v1/events?deviceId={device_id}&projectId={project_id}"),
         json=[
             {
                 "id": "1",
@@ -88,11 +89,12 @@ def test_get_events():
                 "end": end.astimezone().isoformat(),
                 "createdAt": now.astimezone().isoformat(),
                 "updatedAt": now.astimezone().isoformat(),
+                "projectId": project_id,
             }
         ],
     )
     client = Client("test")
-    [event] = client.get_events(device_id=device_id)
+    [event] = client.get_events(device_id=device_id, project_id=project_id)
     assert event["id"] == "1"
     assert event["device_id"] == device_id
     assert event["device"] == {"id": device_id, "name": device_name}
@@ -104,7 +106,7 @@ def test_get_events():
 
     responses.add(
         responses.GET,
-        api_url(f"/v1/events?deviceName={device_name}"),
+        api_url(f"/v1/events?deviceName={device_name}&projectId={project_id}"),
         json=[
             {
                 "id": "1",
@@ -118,11 +120,12 @@ def test_get_events():
                 "end": end.astimezone().isoformat(),
                 "createdAt": now.astimezone().isoformat(),
                 "updatedAt": now.astimezone().isoformat(),
+                "projectId": project_id,
             }
         ],
     )
     client = Client("test")
-    [event] = client.get_events(device_name=device_name)
+    [event] = client.get_events(device_name=device_name, project_id=project_id)
     assert event["id"] == "1"
     assert event["device_id"] == device_id
     assert event["device"] == {"id": device_id, "name": device_name}

--- a/tests/test_recordings.py
+++ b/tests/test_recordings.py
@@ -36,6 +36,7 @@ def test_get_recordings():
     site_id = fake.uuid4()
     edge_site_id = fake.uuid4()
     now = datetime.now(tzoffset(None, 0))
+    project_id = "prj_123"
 
     responses.add(
         responses.GET,
@@ -55,6 +56,7 @@ def test_get_recordings():
                 "device": {"id": device_id, "name": "deviceName"},
                 "metadata": {"hey": "now", "brown": "cow"},
                 "key": "recording_key",
+                "projectId": project_id,
             },
             {
                 "id": recording_id_b,
@@ -67,6 +69,7 @@ def test_get_recordings():
                 "importStatus": "none",
                 "edgeSite": {"id": edge_site_id, "name": "edgeSite"},
                 "device": {"id": device_id, "name": "deviceName"},
+                "projectId": project_id,
             },
         ],
     )
@@ -75,6 +78,7 @@ def test_get_recordings():
         start=datetime.now(),
         end=datetime.now(),
         device_id=device_id,
+        project_id=project_id,
     )
     assert recordings == [
         {
@@ -92,6 +96,7 @@ def test_get_recordings():
             "device": {"id": device_id, "name": "deviceName"},
             "metadata": {"hey": "now", "brown": "cow"},
             "key": "recording_key",
+            "project_id": project_id,
         },
         {
             "id": recording_id_b,
@@ -108,5 +113,6 @@ def test_get_recordings():
             "device": {"id": device_id, "name": "deviceName"},
             "metadata": None,
             "key": None,
+            "project_id": project_id,
         },
     ]


### PR DESCRIPTION
### Changelog

Add `project_id` support.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description

An optional `project_id` parameter can now be passed into the following functions to create or filter resources by Project:
 - `create_device`
 - `get_attachments`
 - `get_coverage`
 - `get_devices`
 - `get_events`
 - `get_recordings`
 - `get_topics`
 - `upload_data`