### PR TITLE
handle missing projectId in get_device response

### DIFF
--- a/foxglove/client.py
+++ b/foxglove/client.py
@@ -537,7 +537,7 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
-            "project_id": device["projectId"],
+            "project_id": device["projectId"] if "projectId" in device else None,
         }
 
     def get_devices(self, *, project_id: Optional[str] = None):
@@ -558,7 +558,7 @@ class Client:
                 "id": d["id"],
                 "name": d["name"],
                 "properties": d["properties"] if "properties" in d else None,
-                "project_id": d["projectId"],
+                "project_id": d["projectId"] if "projectId" in d else None,
             }
             for d in json
         ]
@@ -597,7 +597,7 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
-            "project_id": device["projectId"],
+            "project_id": device["projectId"] if "projectId" in device else None,
         }
 
     def update_device(
@@ -634,7 +634,7 @@ class Client:
             "id": device["id"],
             "name": device["name"],
             "properties": device["properties"] if "properties" in device else None,
-            "project_id": device["projectId"],
+            "project_id": device["projectId"] if "projectId" in device else None,
         }
 
     def delete_device(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -95,6 +95,20 @@ def test_get_device():
     assert device["properties"] is None
     assert device["project_id"] == project_id
 
+    # projectId is optional on the API response
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/devices/{name}"),
+        json={
+            "id": id,
+            "name": fake.sentence(2),
+        },
+    )
+    device = client.get_device(device_name=name)
+    assert device["id"] == id
+    assert device["properties"] is None
+    assert device["project_id"] is None
+
 
 @responses.activate
 def test_get_devices():


### PR DESCRIPTION
### Changelog

Handle missing projectId in get_device response

### Docs

None

### Description

Gracefully handle a missing Project ID in device methods. The `projectId` field is optional on the API response that these methods call.