### PR TITLE
List all projects using the get_projects method

### DIFF
--- a/foxglove/client.py
+++ b/foxglove/client.py
@@ -973,7 +973,7 @@ class Client:
             {
                 "id": p["id"],
                 "name": p.get("name"),
-                "org_member_count": p["orgMemberCount"],
+                "org_member_count": p.get("orgMemberCount", 0),
                 "last_seen_at": arrow.get(p["lastSeenAt"]).datetime
                 if p.get("lastSeenAt")
                 else None,

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -18,7 +18,6 @@ def test_get_projects():
     project1_last_seen_at = datetime(2025, 1, 1, 12, 0, 0)
 
     project2_id = fake.uuid4()
-    project2_org_member_count = 0
 
     responses.add(
         responses.GET,
@@ -32,7 +31,6 @@ def test_get_projects():
             },
             {
                 "id": project2_id,
-                "orgMemberCount": project2_org_member_count,
             },
         ],
     )
@@ -50,7 +48,7 @@ def test_get_projects():
     project2 = next(p for p in projects if p["id"] == project2_id)
     assert project2["id"] == project2_id
     assert project2["name"] is None
-    assert project2["org_member_count"] == project2_org_member_count
+    assert project2["org_member_count"] == 0
     assert project2["last_seen_at"] is None
 
 


### PR DESCRIPTION
### Changelog

Introduces a get_projects method to list all projects available in the organization.

### Docs

None

### Description

You can now use the new `get_projects` shorthand to list projects. This method takes no arguments.

Example usage:

```python
from foxglove.client import Client

token = "<YOUR API TOKEN HERE>"
client = Client(token=token)

projects = client.get_projects()

print(f"Found {len(projects)} projects:\n")

for project in projects:
    print(f"  ID: {project['id']}")
    print(f"  Name: {project['name'] or 'Unnamed'}")
    print(f"  Member Count: {project['org_member_count'] or '0'}")
    print(f"  Last Seen: {project['last_seen_at'] or 'Never'}")
```