### PR TITLE
add support for custom properties on sessions

### DIFF
--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1294,7 +1294,7 @@ class Client:
         remove_recording_ids: IDs of recordings to remove from the session.
         properties: Optional custom properties for the session.
             Each key must be defined as a custom property for your organization,
-            and each value must be of the appropriate type
+            and each value must be of the appropriate type.
         """
         identifier = _session_identifier(session_id, session_key)
 

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1245,7 +1245,7 @@ class Client:
         device_id: Optional[str] = None,
         key: Optional[str] = None,
         recording_ids: Optional[List[str]] = None,
-        properties: Optional[Dict[str, Union[str, bool, float, int]]] = None
+        properties: Optional[Dict[str, Union[str, bool, float, int]]] = None,
     ):
         """Creates a new session.
 
@@ -1254,9 +1254,9 @@ class Client:
         key: An optional user-supplied identifier, unique within the project.
         recording_ids: IDs of recordings to associate with the new session.
             All recordings must belong to the same device.
-        properties: Optional custom properties for the session.
-            Each key must be defined as a custom property for your organization,
-            and each value must be of the appropriate type
+        properties: Optional custom properties to add to or edit on the session.
+            Each key must be defined as a custom property for your organization
+            and each value must be of the appropriate type.
         """
 
         if device_id is None and recording_ids is None:

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1254,8 +1254,8 @@ class Client:
         key: An optional user-supplied identifier, unique within the project.
         recording_ids: IDs of recordings to associate with the new session.
             All recordings must belong to the same device.
-        properties: Optional custom properties to add to or edit on the session.
-            Each key must be defined as a custom property for your organization
+        properties: Optional custom properties for the session.
+            Each key must be defined as a custom property for your organization,
             and each value must be of the appropriate type.
         """
 
@@ -1292,9 +1292,9 @@ class Client:
         project_id: The Project ID to which the session belongs.
         add_recording_ids: IDs of recordings to add to the session.
         remove_recording_ids: IDs of recordings to remove from the session.
-        properties: Optional custom properties for the session.
+        properties: Optional custom properties to add to or edit on the session.
             Each key must be defined as a custom property for your organization,
-            and each value must be of the appropriate type
+            and each value must be of the appropriate type.
         """
         identifier = _session_identifier(session_id, session_key)
 

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1245,6 +1245,7 @@ class Client:
         device_id: Optional[str] = None,
         key: Optional[str] = None,
         recording_ids: Optional[List[str]] = None,
+        properties: Optional[Dict[str, Union[str, bool, float, int]]] = None
     ):
         """Creates a new session.
 
@@ -1253,6 +1254,9 @@ class Client:
         key: An optional user-supplied identifier, unique within the project.
         recording_ids: IDs of recordings to associate with the new session.
             All recordings must belong to the same device.
+        properties: Optional custom properties for the session.
+            Each key must be defined as a custom property for your organization,
+            and each value must be of the appropriate type
         """
 
         if device_id is None and recording_ids is None:
@@ -1262,6 +1266,7 @@ class Client:
             "deviceId": device_id,
             "key": key,
             "recordingIds": recording_ids,
+            "properties": properties,
         }
         response = self.__session.post(
             self.__url__("/v1/sessions"),
@@ -1278,6 +1283,7 @@ class Client:
         project_id: str,
         add_recording_ids: Optional[List[str]] = None,
         remove_recording_ids: Optional[List[str]] = None,
+        properties: Optional[Dict[str, Union[str, bool, float, int]]] = None,
     ):
         """Updates a session.
 
@@ -1286,12 +1292,16 @@ class Client:
         project_id: The Project ID to which the session belongs.
         add_recording_ids: IDs of recordings to add to the session.
         remove_recording_ids: IDs of recordings to remove from the session.
+        properties: Optional custom properties for the session.
+            Each key must be defined as a custom property for your organization,
+            and each value must be of the appropriate type
         """
         identifier = _session_identifier(session_id, session_key)
 
         params = {
             "addRecordingIds": add_recording_ids,
             "removeRecordingIds": remove_recording_ids,
+            "properties": properties,
         }
         response = self.__session.patch(
             self.__url__(f"/v1/sessions/{urlquote(identifier, safe='')}"),
@@ -1368,10 +1378,11 @@ def _session_dict(session):
         "id": session["id"],
         "project_id": session["projectId"],
         "device": session["device"],
-        "key": session["key"],
+        "key": session.get("key"),
         "created_at": arrow.get(session["createdAt"]).datetime,
         "updated_at": arrow.get(session["updatedAt"]).datetime,
         "recordings": session["recordings"],
+        "properties": session.get("properties"),
     }
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -21,6 +21,7 @@ def _make_session_json(
     device_name=None,
     key=None,
     recording_ids=None,
+    properties=None,
 ):
     session_id = session_id or fake.uuid4()
     project_id = project_id or fake.uuid4()
@@ -35,6 +36,7 @@ def _make_session_json(
         "createdAt": NOW.isoformat(),
         "updatedAt": NOW.isoformat(),
         "recordings": [{"id": rid} for rid in (recording_ids or [])],
+        "properties": properties,
     }
 
 
@@ -61,6 +63,7 @@ def test_get_sessions():
     assert result[0]["created_at"] == arrow.get(s1["createdAt"]).datetime
     assert result[0]["updated_at"] == arrow.get(s1["updatedAt"]).datetime
     assert result[0]["recordings"] == s1["recordings"]
+    assert result[0]["properties"] == s1["properties"]
 
 
 @responses.activate
@@ -105,18 +108,22 @@ def test_get_session_by_key():
 def test_create_session():
     device_id = fake.uuid4()
     key = "test-session"
-    s = _make_session_json(device_id=device_id, key=key)
+    props = {"vehicle": "truck", "active": True, "distance": 42.5}
+    s = _make_session_json(device_id=device_id, key=key, properties=props)
     responses.add(
         responses.POST,
         api_url("/v1/sessions"),
         match=[
-            json_params_matcher({"deviceId": device_id, "key": key}),
+            json_params_matcher(
+                {"deviceId": device_id, "key": key, "properties": props}
+            ),
         ],
         json=s,
     )
     client = Client("test")
-    result = client.create_session(device_id=device_id, key=key)
+    result = client.create_session(device_id=device_id, key=key, properties=props)
     assert result["key"] == key
+    assert result["properties"] == props
 
 
 @responses.activate
@@ -124,17 +131,19 @@ def test_update_session():
     session_id = fake.uuid4()
     project_id = fake.uuid4()
     add_ids = [fake.uuid4()]
+    props = {"vehicle": "truck", "active": True, "distance": 42.5}
     s = _make_session_json(
         session_id=session_id,
         project_id=project_id,
         recording_ids=add_ids,
+        properties=props,
     )
     responses.add(
         responses.PATCH,
         api_url(f"/v1/sessions/{session_id}"),
         match=[
             query_string_matcher(f"projectId={project_id}"),
-            json_params_matcher({"addRecordingIds": add_ids}),
+            json_params_matcher({"addRecordingIds": add_ids, "properties": props}),
         ],
         json=s,
     )
@@ -143,8 +152,10 @@ def test_update_session():
         session_id=session_id,
         project_id=project_id,
         add_recording_ids=add_ids,
+        properties=props,
     )
     assert result["id"] == session_id
+    assert result["properties"] == props
 
 
 @responses.activate


### PR DESCRIPTION
### Changelog
- Add support for custom property add / edit on sessions.
- Fixes an error when retrieving sessions that have no key set.

### Docs

None

### Description

This is in line with other methods that support custom properties (devices, events)