### PR TITLE
support for device custom property intervals

### DIFF
--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1333,7 +1333,7 @@ class Client:
         id: str,
     ):
         """
-        Fetches a single device custom propety time intervalrecord.
+        Fetches a single device custom property time interval record.
 
         device_id: The ID of the device to retrieve the time interval record from.
             Use this or device_name.
@@ -1514,14 +1514,14 @@ def _session_dict(session):
     }
 
 
-def _device_custom_property_time_interval_dict(property_history):
-    end = property_history.get("end")
+def _device_custom_property_time_interval_dict(interval):
+    end = interval.get("end")
     return {
-        "id": property_history["id"],
-        "device_id": property_history["deviceId"],
-        "key": property_history["key"],
-        "value": property_history["value"],
-        "start": arrow.get(property_history["start"]).datetime,
+        "id": interval["id"],
+        "device_id": interval["deviceId"],
+        "key": interval["key"],
+        "value": interval["value"],
+        "start": arrow.get(interval["start"]).datetime,
         "end": arrow.get(end).datetime if end else None,
     }
 

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -651,12 +651,9 @@ class Client:
         :param project_id: Project to retrieve the device from.
             Required for multi-project organizations.
         """
-        if device_name and device_id:
-            raise RuntimeError("device_id and device_name are mutually exclusive")
-        if device_name is None and device_id is None:
-            raise RuntimeError("device_id or device_name must be provided")
+        identifier = _device_identifier(device_id, device_name)
         response = self.__session.get(
-            self.__url__(f"/v1/devices/{device_name or device_id}"),
+            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
             params={"projectId": project_id} if project_id is not None else None,
         )
 
@@ -728,13 +725,10 @@ class Client:
         :param project_id: Project to retrieve the device from.
             Required for multi-project organizations.
         """
-        if device_name and device_id:
-            raise RuntimeError("device_id and device_name are mutually exclusive")
-        if device_name is None and device_id is None:
-            raise RuntimeError("device_id or device_name must be provided")
+        identifier = _device_identifier(device_id, device_name)
 
         response = self.__session.patch(
-            self.__url__(f"/v1/devices/{device_name or device_id}"),
+            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
             params={"projectId": project_id} if project_id is not None else None,
             json=without_nulls({"name": new_name, "properties": properties}),
         )
@@ -758,12 +752,9 @@ class Client:
         :param project_id: Project to delete the device from.
             Required for multi-project organizations.
         """
-        if device_name and device_id:
-            raise RuntimeError("device_id and device_name are mutually exclusive")
-        if device_name is None and device_id is None:
-            raise RuntimeError("device_id or device_name must be provided")
+        identifier = _device_identifier(device_id, device_name)
         response = self.__session.delete(
-            self.__url__(f"/v1/devices/{device_name or device_id}"),
+            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
             params={"projectId": project_id} if project_id is not None else None,
         )
         json_or_raise(response)
@@ -1333,6 +1324,133 @@ class Client:
 
         return json_or_raise(response)
 
+    def get_device_custom_property_history(
+        self,
+        *,
+        device_id: Optional[str] = None,
+        device_name: Optional[str] = None,
+        project_id: Optional[str] = None,
+        id: str,
+    ):
+        """
+        Fetches a single device custom property history record.
+
+        device_id: The ID of the device to retrieve the history record from.
+            Use this or name.
+        device_name: The name of the device to retrieve the history record from.
+            Use this or device_id.
+        project_id: Project to retrieve the history record from.
+            Required for multi-project organizations.
+        id: The ID of the history record to fetch.
+        """
+        identifier = _device_identifier(device_id, device_name)
+
+        response = self.__session.get(
+            self.__url__(
+                f"/v1/devices/{urlquote(identifier, safe='')}/property-history/"
+                f"{urlquote(id, safe='')}"
+            ),
+            params=without_nulls({"projectId": project_id}),
+        )
+        return _device_custom_property_history_dict(json_or_raise(response))
+
+    def get_device_custom_property_history_records(
+        self,
+        *,
+        device_id: Optional[str] = None,
+        device_name: Optional[str] = None,
+        project_id: Optional[str] = None,
+        key: Optional[str] = None,
+        start: Optional[datetime.datetime] = None,
+        end: Optional[datetime.datetime] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ):
+        """
+        Lists device custom property history records.
+
+        device_id: The ID of the device to retrieve history records from.
+            Use this or name.
+        device_name: The name of the device to retrieve history records from.
+            Use this or id.
+        project_id: Project to retrieve history records from.
+            Required for multi-project organizations.
+        key: Optional property key to filter by.
+        start: Optionally include records active at or after this time.
+        end: Optionally include records active before this time.
+        limit: Optionally limit the number of history records returned.
+        offset: Optionally offset the history records by this many records.
+        """
+        identifier = _device_identifier(device_id, device_name)
+
+        params = {
+            "projectId": project_id,
+            "key": key,
+            "start": start.astimezone().isoformat() if start else None,
+            "end": end.astimezone().isoformat() if end else None,
+            "limit": limit,
+            "offset": offset,
+        }
+
+        response = self.__session.get(
+            self.__url__(
+                f"/v1/devices/{urlquote(identifier, safe='')}/property-history"
+            ),
+            params={k: v for k, v in params.items() if v is not None},
+        )
+        return [
+            _device_custom_property_history_dict(r) for r in json_or_raise(response)
+        ]
+
+    def update_device_custom_property_history(
+        self,
+        *,
+        device_id: Optional[str] = None,
+        device_name: Optional[str] = None,
+        project_id: Optional[str] = None,
+        key: str,
+        value: Optional[Union[str, bool, float, int, List[str]]] = None,
+        start: datetime.datetime,
+        end: datetime.datetime,
+    ):
+        """
+        Updates device custom property history over a time range.
+
+        The request is treated as an assertion of truth for the given range,
+        so existing records may be split, trimmed, or deleted as needed.
+
+        device_id: The ID of the device to update history for.
+            Use this or name.
+        device_name: The name of the device to update history for.
+            Use this or device_id.
+        project_id: Project to update history in.
+            Required for multi-project organizations.
+        key: The property key to update.
+        value: The value to apply over the given time range.
+            When omitted, the value will be treated as explicitly unset for that range.
+        start: Inclusive start of the property's effective time range.
+        end: Exclusive end of the property's effective time range.
+        """
+        identifier = _device_identifier(device_id, device_name)
+
+        params: Dict[str, Any] = {
+            "projectId": project_id,
+            "key": key,
+            "value": value,
+            "start": start.astimezone().isoformat(),
+            "end": end.astimezone().isoformat(),
+        }
+        params["deviceId" if device_id is not None else "deviceName"] = identifier
+
+        response = self.__session.post(
+            self.__url__("/v1/actions/devices/update-device-property-history"),
+            json=without_nulls(params),
+        )
+        # This endpoint returns 204 No Content on success (no body)
+        if response.status_code == 204:
+            return None
+        return json_or_raise(response)
+
 
 def _session_identifier(session_id: Optional[str], session_key: Optional[str]) -> str:
     if session_id is not None and session_key is not None:
@@ -1342,6 +1460,17 @@ def _session_identifier(session_id: Optional[str], session_key: Optional[str]) -
 
     identifier = session_id if session_id is not None else session_key
     assert identifier is not None, "one of session_id or session_key must be provided"
+    return identifier
+
+
+def _device_identifier(device_id: Optional[str], device_name: Optional[str]) -> str:
+    if device_id is not None and device_name is not None:
+        raise RuntimeError("device_id and device_name are mutually exclusive")
+    if device_id is None and device_name is None:
+        raise RuntimeError("device_id or device_name must be provided")
+
+    identifier = device_id if device_id is not None else device_name
+    assert identifier is not None, "one of device_id or device_name must be provided"
     return identifier
 
 
@@ -1383,6 +1512,18 @@ def _session_dict(session):
         "updated_at": arrow.get(session["updatedAt"]).datetime,
         "recordings": session["recordings"],
         "properties": session.get("properties"),
+    }
+
+
+def _device_custom_property_history_dict(property_history):
+    end = property_history.get("end")
+    return {
+        "id": property_history["id"],
+        "device_id": property_history["deviceId"],
+        "key": property_history["key"],
+        "value": property_history["value"],
+        "start": arrow.get(property_history["start"]).datetime,
+        "end": arrow.get(end).datetime if end else None,
     }
 
 

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1336,7 +1336,7 @@ class Client:
         Fetches a single device custom property history record.
 
         device_id: The ID of the device to retrieve the history record from.
-            Use this or name.
+            Use this or device_name.
         device_name: The name of the device to retrieve the history record from.
             Use this or device_id.
         project_id: Project to retrieve the history record from.
@@ -1370,9 +1370,9 @@ class Client:
         Lists device custom property history records.
 
         device_id: The ID of the device to retrieve history records from.
-            Use this or name.
+            Use this or device_name.
         device_name: The name of the device to retrieve history records from.
-            Use this or id.
+            Use this or device_id.
         project_id: Project to retrieve history records from.
             Required for multi-project organizations.
         key: Optional property key to filter by.
@@ -1420,7 +1420,7 @@ class Client:
         so existing records may be split, trimmed, or deleted as needed.
 
         device_id: The ID of the device to update history for.
-            Use this or name.
+            Use this or device_name.
         device_name: The name of the device to update history for.
             Use this or device_id.
         project_id: Project to update history in.

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1344,7 +1344,7 @@ class Client:
         id: str,
     ):
         """
-        Fetches a single device custom property time interval record.
+        Fetches a single device custom property time interval record for the given device.
 
         device_id: The ID of the device to retrieve the time interval record from.
             Use this or device_name.
@@ -1424,7 +1424,7 @@ class Client:
         end: datetime.datetime,
     ):
         """
-        Updates device custom property time intervals over a time range.
+        Updates device custom property time intervals over a time range for the given device.
 
         The request is treated as an assertion of truth for the given range,
         so existing intervals may be split, trimmed, or deleted as needed.

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1324,7 +1324,7 @@ class Client:
 
         return json_or_raise(response)
 
-    def get_device_custom_property_history(
+    def get_device_custom_property_time_interval(
         self,
         *,
         device_id: Optional[str] = None,
@@ -1333,28 +1333,27 @@ class Client:
         id: str,
     ):
         """
-        Fetches a single device custom property history record.
+        Fetches a single device custom propety time intervalrecord.
 
-        device_id: The ID of the device to retrieve the history record from.
+        device_id: The ID of the device to retrieve the time interval record from.
             Use this or device_name.
-        device_name: The name of the device to retrieve the history record from.
+        device_name: The name of the device to retrieve the time interval record from.
             Use this or device_id.
-        project_id: Project to retrieve the history record from.
-            Required for multi-project organizations.
-        id: The ID of the history record to fetch.
+        project_id: Project associated with the device. Required for multi-project organizations.
+        id: The ID of the time interval record to fetch.
         """
         identifier = _device_identifier(device_id, device_name)
 
         response = self.__session.get(
             self.__url__(
-                f"/v1/devices/{urlquote(identifier, safe='')}/property-history/"
+                f"/v1/devices/{urlquote(identifier, safe='')}/property-time-intervals/"
                 f"{urlquote(id, safe='')}"
             ),
             params=without_nulls({"projectId": project_id}),
         )
-        return _device_custom_property_history_dict(json_or_raise(response))
+        return _device_custom_property_time_interval_dict(json_or_raise(response))
 
-    def get_device_custom_property_history_records(
+    def get_device_custom_property_time_intervals(
         self,
         *,
         device_id: Optional[str] = None,
@@ -1367,19 +1366,18 @@ class Client:
         offset: Optional[int] = None,
     ):
         """
-        Lists device custom property history records.
+        Lists device custom property time intervals.
 
-        device_id: The ID of the device to retrieve history records from.
+        device_id: The ID of the device to retrieve time intervals from.
             Use this or device_name.
-        device_name: The name of the device to retrieve history records from.
+        device_name: The name of the device to retrieve time intervals from.
             Use this or device_id.
-        project_id: Project to retrieve history records from.
-            Required for multi-project organizations.
+        project_id: Project associated with the device. Required for multi-project organizations.
         key: Optional property key to filter by.
-        start: Optionally include records active at or after this time.
-        end: Optionally include records active before this time.
-        limit: Optionally limit the number of history records returned.
-        offset: Optionally offset the history records by this many records.
+        start: Optionally include intervals active at or after this time.
+        end: Optionally include intervals active before this time.
+        limit: Optionally limit the number of time intervals returned.
+        offset: Optionally offset the time intervals by this many intervals.
         """
         identifier = _device_identifier(device_id, device_name)
 
@@ -1394,15 +1392,16 @@ class Client:
 
         response = self.__session.get(
             self.__url__(
-                f"/v1/devices/{urlquote(identifier, safe='')}/property-history"
+                f"/v1/devices/{urlquote(identifier, safe='')}/property-time-intervals"
             ),
             params={k: v for k, v in params.items() if v is not None},
         )
         return [
-            _device_custom_property_history_dict(r) for r in json_or_raise(response)
+            _device_custom_property_time_interval_dict(r)
+            for r in json_or_raise(response)
         ]
 
-    def update_device_custom_property_history(
+    def update_device_custom_property_time_intervals(
         self,
         *,
         device_id: Optional[str] = None,
@@ -1414,17 +1413,16 @@ class Client:
         end: datetime.datetime,
     ):
         """
-        Updates device custom property history over a time range.
+        Updates device custom property time intervals over a time range.
 
         The request is treated as an assertion of truth for the given range,
-        so existing records may be split, trimmed, or deleted as needed.
+        so existing intervals may be split, trimmed, or deleted as needed.
 
-        device_id: The ID of the device to update history for.
+        device_id: The ID of the device to update time intervals for.
             Use this or device_name.
-        device_name: The name of the device to update history for.
+        device_name: The name of the device to update time intervals for.
             Use this or device_id.
-        project_id: Project to update history in.
-            Required for multi-project organizations.
+        project_id: Project associated with the device. Required for multi-project organizations.
         key: The property key to update.
         value: The value to apply over the given time range.
             When omitted, the value will be treated as explicitly unset for that range.
@@ -1440,10 +1438,11 @@ class Client:
             "start": start.astimezone().isoformat(),
             "end": end.astimezone().isoformat(),
         }
-        params["deviceId" if device_id is not None else "deviceName"] = identifier
 
         response = self.__session.post(
-            self.__url__("/v1/actions/devices/update-device-property-history"),
+            self.__url__(
+                f"/v1/actions/devices/{urlquote(identifier, safe='')}/update-property-time-interval"
+            ),
             json=without_nulls(params),
         )
         # This endpoint returns 204 No Content on success (no body)
@@ -1515,7 +1514,7 @@ def _session_dict(session):
     }
 
 
-def _device_custom_property_history_dict(property_history):
+def _device_custom_property_time_interval_dict(property_history):
     end = property_history.get("end")
     return {
         "id": property_history["id"],

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1412,7 +1412,7 @@ class Client:
             for r in json_or_raise(response)
         ]
 
-    def update_device_custom_property_time_intervals(
+    def update_device_custom_property_time_interval(
         self,
         *,
         device_id: Optional[str] = None,

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -74,6 +74,17 @@ def bool_query_param(val: bool) -> Optional[str]:
     return str(val).lower() if val is not None else None
 
 
+def comma_separated_query_param(val: Optional[Union[str, List[str]]]) -> Optional[str]:
+    """
+    Serialize a string or list of strings to a comma-separated query parameter.
+    """
+    if val is None:
+        return None
+    if isinstance(val, list):
+        return ",".join(val) if val else None
+    return val
+
+
 def without_nulls(params: Dict[str, Union[T, None]]) -> Dict[str, T]:
     """
     Filter out `None` values from params
@@ -1359,7 +1370,7 @@ class Client:
         device_id: Optional[str] = None,
         device_name: Optional[str] = None,
         project_id: Optional[str] = None,
-        key: Optional[str] = None,
+        key: Optional[Union[str, List[str]]] = None,
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
         limit: Optional[int] = None,
@@ -1373,7 +1384,7 @@ class Client:
         device_name: The name of the device to retrieve time intervals from.
             Use this or device_id.
         project_id: Project associated with the device. Required for multi-project organizations.
-        key: Optional property key to filter by.
+        key: Optional property key or keys to filter by.
         start: Optionally include intervals active at or after this time.
         end: Optionally include intervals active before this time.
         limit: Optionally limit the number of time intervals returned.
@@ -1383,7 +1394,7 @@ class Client:
 
         params = {
             "projectId": project_id,
-            "key": key,
+            "key": comma_separated_query_param(key),
             "start": start.astimezone().isoformat() if start else None,
             "end": end.astimezone().isoformat() if end else None,
             "limit": limit,

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -662,9 +662,9 @@ class Client:
         :param project_id: Project to retrieve the device from.
             Required for multi-project organizations.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
         response = self.__session.get(
-            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/devices/{identifier}"),
             params={"projectId": project_id} if project_id is not None else None,
         )
 
@@ -736,10 +736,10 @@ class Client:
         :param project_id: Project to retrieve the device from.
             Required for multi-project organizations.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
 
         response = self.__session.patch(
-            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/devices/{identifier}"),
             params={"projectId": project_id} if project_id is not None else None,
             json=without_nulls({"name": new_name, "properties": properties}),
         )
@@ -763,9 +763,9 @@ class Client:
         :param project_id: Project to delete the device from.
             Required for multi-project organizations.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
         response = self.__session.delete(
-            self.__url__(f"/v1/devices/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/devices/{identifier}"),
             params={"projectId": project_id} if project_id is not None else None,
         )
         json_or_raise(response)
@@ -1233,10 +1233,10 @@ class Client:
         session_key: The key of the session to fetch
         project_id: The project ID to fetch the session from.
         """
-        identifier = _session_identifier(session_id, session_key)
+        identifier = _session_identifier_for_path(session_id, session_key)
 
         response = self.__session.get(
-            self.__url__(f"/v1/sessions/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/sessions/{identifier}"),
             params={"projectId": project_id},
         )
         return _session_dict(json_or_raise(response))
@@ -1298,7 +1298,7 @@ class Client:
             Each key must be defined as a custom property for your organization,
             and each value must be of the appropriate type.
         """
-        identifier = _session_identifier(session_id, session_key)
+        identifier = _session_identifier_for_path(session_id, session_key)
 
         params = {
             "addRecordingIds": add_recording_ids,
@@ -1306,7 +1306,7 @@ class Client:
             "properties": properties,
         }
         response = self.__session.patch(
-            self.__url__(f"/v1/sessions/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/sessions/{identifier}"),
             params={"projectId": project_id},
             json={k: v for k, v in params.items() if v is not None},
         )
@@ -1326,10 +1326,10 @@ class Client:
         session_key: The key of the session to delete.
         project_id: The Project ID to which the session belongs.
         """
-        identifier = _session_identifier(session_id, session_key)
+        identifier = _session_identifier_for_path(session_id, session_key)
 
         response = self.__session.delete(
-            self.__url__(f"/v1/sessions/{urlquote(identifier, safe='')}"),
+            self.__url__(f"/v1/sessions/{identifier}"),
             params={"projectId": project_id},
         )
 
@@ -1353,11 +1353,11 @@ class Client:
         project_id: Project associated with the device. Required for multi-project organizations.
         id: The ID of the time interval record to fetch.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
 
         response = self.__session.get(
             self.__url__(
-                f"/v1/devices/{urlquote(identifier, safe='')}/property-time-intervals/"
+                f"/v1/devices/{identifier}/property-time-intervals/"
                 f"{urlquote(id, safe='')}"
             ),
             params=without_nulls({"projectId": project_id}),
@@ -1390,7 +1390,7 @@ class Client:
         limit: Optionally limit the number of time intervals returned.
         offset: Optionally offset the time intervals by this many intervals.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
 
         params = {
             "projectId": project_id,
@@ -1402,9 +1402,7 @@ class Client:
         }
 
         response = self.__session.get(
-            self.__url__(
-                f"/v1/devices/{urlquote(identifier, safe='')}/property-time-intervals"
-            ),
+            self.__url__(f"/v1/devices/{identifier}/property-time-intervals"),
             params={k: v for k, v in params.items() if v is not None},
         )
         return [
@@ -1440,7 +1438,7 @@ class Client:
         start: Inclusive start of the property's effective time range.
         end: Exclusive end of the property's effective time range.
         """
-        identifier = _device_identifier(device_id, device_name)
+        identifier = _device_identifier_for_path(device_id, device_name)
 
         params: Dict[str, Any] = {
             "projectId": project_id,
@@ -1452,7 +1450,7 @@ class Client:
 
         response = self.__session.post(
             self.__url__(
-                f"/v1/actions/devices/{urlquote(identifier, safe='')}/update-property-time-interval"
+                f"/v1/actions/devices/{identifier}/update-property-time-interval"
             ),
             json=without_nulls(params),
         )
@@ -1473,6 +1471,12 @@ def _session_identifier(session_id: Optional[str], session_key: Optional[str]) -
     return identifier
 
 
+def _session_identifier_for_path(
+    session_id: Optional[str], session_key: Optional[str]
+) -> str:
+    return urlquote(_session_identifier(session_id, session_key), safe="")
+
+
 def _device_identifier(device_id: Optional[str], device_name: Optional[str]) -> str:
     if device_id is not None and device_name is not None:
         raise RuntimeError("device_id and device_name are mutually exclusive")
@@ -1482,6 +1486,12 @@ def _device_identifier(device_id: Optional[str], device_name: Optional[str]) -> 
     identifier = device_id if device_id is not None else device_name
     assert identifier is not None, "one of device_id or device_name must be provided"
     return identifier
+
+
+def _device_identifier_for_path(
+    device_id: Optional[str], device_name: Optional[str]
+) -> str:
+    return urlquote(_device_identifier(device_id, device_name), safe="")
 
 
 def _event_dict(json_event):

--- a/tests/test_device_custom_property_history.py
+++ b/tests/test_device_custom_property_history.py
@@ -1,0 +1,136 @@
+import json
+from datetime import datetime
+from urllib.parse import parse_qs, quote, urlparse
+
+import pytest
+import responses
+from faker import Faker
+
+from foxglove.client import Client
+
+from .api_url import api_url
+
+fake = Faker()
+
+
+@responses.activate
+def test_get_device_custom_property_history_quotes_path_and_passes_project_id():
+    device_name = "Device / Name"
+    property_history_id = "dcph/id"
+    now = datetime.now()
+    responses.add(
+        responses.GET,
+        api_url(
+            f"/v1/devices/{quote(device_name, safe='')}/property-history/"
+            f"{quote(property_history_id, safe='')}"
+        ),
+        json={
+            "id": property_history_id,
+            "deviceId": fake.uuid4(),
+            "key": "env",
+            "value": "prod",
+            "start": now.isoformat(),
+            "end": now.isoformat(),
+        },
+    )
+
+    client = Client("test")
+    response = client.get_device_custom_property_history(
+        device_name=device_name,
+        project_id="project-id",
+        id=property_history_id,
+    )
+
+    assert response["id"] == property_history_id
+    assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
+        "projectId": ["project-id"]
+    }
+
+
+def test_get_device_custom_property_history_rejects_multiple_device_selectors():
+    client = Client("test")
+
+    with pytest.raises(RuntimeError) as exception:
+        client.get_device_custom_property_history(
+            device_id="device-id",
+            device_name="device-name",
+            id="history-id",
+        )
+
+    assert str(exception.value) == "device_id and device_name are mutually exclusive"
+
+
+@responses.activate
+def test_get_device_custom_property_history_records_uses_path_selector_only():
+    device_name = "Device / Name"
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/devices/{quote(device_name, safe='')}/property-history"),
+        json=[],
+    )
+
+    client = Client("test")
+    client.get_device_custom_property_history_records(
+        device_name=device_name,
+        project_id="project-id",
+        key="env",
+        limit=5,
+        offset=10,
+    )
+
+    assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
+        "key": ["env"],
+        "limit": ["5"],
+        "offset": ["10"],
+        "projectId": ["project-id"],
+    }
+
+
+@responses.activate
+def test_update_device_custom_property_history_omits_value_for_clear():
+    responses.add(
+        responses.POST,
+        api_url("/v1/actions/devices/update-device-property-history"),
+        status=204,
+        body="",
+    )
+
+    client = Client("test")
+    client.update_device_custom_property_history(
+        device_name="Device / Name",
+        project_id="project-id",
+        key="env",
+        start=datetime.now(),
+        end=datetime.now(),
+    )
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["deviceName"] == "Device / Name"
+    assert request_body["projectId"] == "project-id"
+    assert request_body["key"] == "env"
+    assert "value" not in request_body
+    assert "deviceId" not in request_body
+
+
+@responses.activate
+def test_update_device_custom_property_history_supports_array_values():
+    responses.add(
+        responses.POST,
+        api_url("/v1/actions/devices/update-device-property-history"),
+        status=204,
+        body="",
+    )
+
+    client = Client("test")
+    client.update_device_custom_property_history(
+        device_id="device-id",
+        key="labels",
+        value=["one", "two"],
+        start=datetime.now(),
+        end=datetime.now(),
+    )
+
+    request_body = json.loads(responses.calls[0].request.body)
+    assert request_body["deviceId"] == "device-id"
+    assert request_body["value"] == ["one", "two"]
+    assert "deviceName" not in request_body

--- a/tests/test_device_custom_property_time_interval.py
+++ b/tests/test_device_custom_property_time_interval.py
@@ -14,18 +14,18 @@ fake = Faker()
 
 
 @responses.activate
-def test_get_device_custom_property_history_quotes_path_and_passes_project_id():
+def test_get_device_custom_property_time_interval_quotes_path_and_passes_project_id():
     device_name = "Device / Name"
-    property_history_id = "dcph/id"
+    time_interval_id = "dcph/id"
     now = datetime.now()
     responses.add(
         responses.GET,
         api_url(
-            f"/v1/devices/{quote(device_name, safe='')}/property-history/"
-            f"{quote(property_history_id, safe='')}"
+            f"/v1/devices/{quote(device_name, safe='')}/property-time-intervals/"
+            f"{quote(time_interval_id, safe='')}"
         ),
         json={
-            "id": property_history_id,
+            "id": time_interval_id,
             "deviceId": fake.uuid4(),
             "key": "env",
             "value": "prod",
@@ -35,42 +35,42 @@ def test_get_device_custom_property_history_quotes_path_and_passes_project_id():
     )
 
     client = Client("test")
-    response = client.get_device_custom_property_history(
+    response = client.get_device_custom_property_time_interval(
         device_name=device_name,
         project_id="project-id",
-        id=property_history_id,
+        id=time_interval_id,
     )
 
-    assert response["id"] == property_history_id
+    assert response["id"] == time_interval_id
     assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
         "projectId": ["project-id"]
     }
 
 
-def test_get_device_custom_property_history_rejects_multiple_device_selectors():
+def test_get_device_custom_property_time_interval_rejects_multiple_device_selectors():
     client = Client("test")
 
     with pytest.raises(RuntimeError) as exception:
-        client.get_device_custom_property_history(
+        client.get_device_custom_property_time_interval(
             device_id="device-id",
             device_name="device-name",
-            id="history-id",
+            id="time-interval-id",
         )
 
     assert str(exception.value) == "device_id and device_name are mutually exclusive"
 
 
 @responses.activate
-def test_get_device_custom_property_history_records_uses_path_selector_only():
+def test_get_device_custom_property_time_intervals_uses_path_selector_only():
     device_name = "Device / Name"
     responses.add(
         responses.GET,
-        api_url(f"/v1/devices/{quote(device_name, safe='')}/property-history"),
+        api_url(f"/v1/devices/{quote(device_name, safe='')}/property-time-intervals"),
         json=[],
     )
 
     client = Client("test")
-    client.get_device_custom_property_history_records(
+    client.get_device_custom_property_time_intervals(
         device_name=device_name,
         project_id="project-id",
         key="env",
@@ -87,17 +87,20 @@ def test_get_device_custom_property_history_records_uses_path_selector_only():
 
 
 @responses.activate
-def test_update_device_custom_property_history_omits_value_for_clear():
+def test_update_device_custom_property_time_intervals_omits_value_for_clear():
+    device_name = "Device / Name"
     responses.add(
         responses.POST,
-        api_url("/v1/actions/devices/update-device-property-history"),
+        api_url(
+            f"/v1/actions/devices/{quote(device_name, safe='')}/update-property-time-interval"
+        ),
         status=204,
         body="",
     )
 
     client = Client("test")
-    client.update_device_custom_property_history(
-        device_name="Device / Name",
+    client.update_device_custom_property_time_intervals(
+        device_name=device_name,
         project_id="project-id",
         key="env",
         start=datetime.now(),
@@ -105,24 +108,24 @@ def test_update_device_custom_property_history_omits_value_for_clear():
     )
 
     request_body = json.loads(responses.calls[0].request.body)
-    assert request_body["deviceName"] == "Device / Name"
     assert request_body["projectId"] == "project-id"
     assert request_body["key"] == "env"
     assert "value" not in request_body
+    assert "deviceName" not in request_body
     assert "deviceId" not in request_body
 
 
 @responses.activate
-def test_update_device_custom_property_history_supports_array_values():
+def test_update_device_custom_property_time_intervals_supports_array_values():
     responses.add(
         responses.POST,
-        api_url("/v1/actions/devices/update-device-property-history"),
+        api_url("/v1/actions/devices/device-id/update-property-time-interval"),
         status=204,
         body="",
     )
 
     client = Client("test")
-    client.update_device_custom_property_history(
+    client.update_device_custom_property_time_intervals(
         device_id="device-id",
         key="labels",
         value=["one", "two"],
@@ -131,6 +134,6 @@ def test_update_device_custom_property_history_supports_array_values():
     )
 
     request_body = json.loads(responses.calls[0].request.body)
-    assert request_body["deviceId"] == "device-id"
     assert request_body["value"] == ["one", "two"]
     assert "deviceName" not in request_body
+    assert "deviceId" not in request_body

--- a/tests/test_device_custom_property_time_interval.py
+++ b/tests/test_device_custom_property_time_interval.py
@@ -120,7 +120,7 @@ def test_update_device_custom_property_time_intervals_omits_value_for_clear():
     )
 
     client = Client("test")
-    client.update_device_custom_property_time_intervals(
+    client.update_device_custom_property_time_interval(
         device_name=device_name,
         project_id="project-id",
         key="env",
@@ -146,7 +146,7 @@ def test_update_device_custom_property_time_intervals_supports_array_values():
     )
 
     client = Client("test")
-    client.update_device_custom_property_time_intervals(
+    client.update_device_custom_property_time_interval(
         device_id="device-id",
         key="labels",
         value=["one", "two"],

--- a/tests/test_device_custom_property_time_interval.py
+++ b/tests/test_device_custom_property_time_interval.py
@@ -87,6 +87,27 @@ def test_get_device_custom_property_time_intervals_uses_path_selector_only():
 
 
 @responses.activate
+def test_get_device_custom_property_time_intervals_supports_multiple_keys():
+    responses.add(
+        responses.GET,
+        api_url("/v1/devices/device-id/property-time-intervals"),
+        json=[],
+    )
+
+    client = Client("test")
+    client.get_device_custom_property_time_intervals(
+        device_id="device-id",
+        project_id="project-id",
+        key=["env", "region"],
+    )
+
+    assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
+        "key": ["env,region"],
+        "projectId": ["project-id"],
+    }
+
+
+@responses.activate
 def test_update_device_custom_property_time_intervals_omits_value_for_clear():
     device_name = "Device / Name"
     responses.add(

--- a/tests/test_device_custom_property_time_interval.py
+++ b/tests/test_device_custom_property_time_interval.py
@@ -108,7 +108,7 @@ def test_get_device_custom_property_time_intervals_supports_multiple_keys():
 
 
 @responses.activate
-def test_update_device_custom_property_time_intervals_omits_value_for_clear():
+def test_update_device_custom_property_time_interval_omits_value_for_clear():
     device_name = "Device / Name"
     responses.add(
         responses.POST,
@@ -137,7 +137,7 @@ def test_update_device_custom_property_time_intervals_omits_value_for_clear():
 
 
 @responses.activate
-def test_update_device_custom_property_time_intervals_supports_array_values():
+def test_update_device_custom_property_time_interval_supports_array_values():
     responses.add(
         responses.POST,
         api_url("/v1/actions/devices/device-id/update-property-time-interval"),

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,4 +1,5 @@
 import datetime
+from urllib.parse import quote
 
 import arrow
 import responses
@@ -93,6 +94,25 @@ def test_get_session_by_key():
     responses.add(
         responses.GET,
         api_url(f"/v1/sessions/{session_key}"),
+        match=[
+            query_string_matcher(f"projectId={project_id}"),
+        ],
+        json=s,
+    )
+    client = Client("test")
+    result = client.get_session(session_key=session_key, project_id=project_id)
+    assert result["key"] == session_key
+    assert result["project_id"] == project_id
+
+
+@responses.activate
+def test_get_session_by_key_quotes_path():
+    session_key = "session / key"
+    project_id = fake.uuid4()
+    s = _make_session_json(key=session_key, project_id=project_id)
+    responses.add(
+        responses.GET,
+        api_url(f"/v1/sessions/{quote(session_key, safe='')}"),
         match=[
             query_string_matcher(f"projectId={project_id}"),
         ],


### PR DESCRIPTION
### Changelog

Support for device custom property time intervals

### Docs

Relevant docs will be updated with the associated API PR

### Description

Pending

Adds support for device custom property time intervals - listing, getting, and updating. Also a small deduplication refactor to consolidate our device id or name handling into a single method. This is in line with how we do session id or key.

### Testing

Local testing against a local API instance. A custom test script was used to hit the API with a high volume of reads and edits and examine the results for correctness.

<img width="457" height="339" alt="Screenshot 2026-03-24 at 1 40 08 PM" src="https://github.com/user-attachments/assets/7f3a4f41-1ae1-45fa-9724-7bc08b4c0ae3" />
