### PR TITLE
Replace key filter with query syntax and add sorting to property time intervals

### DIFF
--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -1375,7 +1375,9 @@ class Client:
         device_name: The name of the device to retrieve time intervals from.
             Use this or device_id.
         project_id: Project associated with the device. Required for multi-project organizations.
-        query: Optional query string to filter device property history.
+        query: optional query string to filter property time intervals by metadata.
+            See https://docs.foxglove.dev/api#tag/Devices/paths/~1devices/get for
+            a syntax definition of `query`.
         start: Optionally include intervals active at or after this time.
         end: Optionally include intervals active before this time.
         sort_by: Optionally sort records by this field name.

--- a/foxglove/client/api.py
+++ b/foxglove/client/api.py
@@ -74,17 +74,6 @@ def bool_query_param(val: bool) -> Optional[str]:
     return str(val).lower() if val is not None else None
 
 
-def comma_separated_query_param(val: Optional[Union[str, List[str]]]) -> Optional[str]:
-    """
-    Serialize a string or list of strings to a comma-separated query parameter.
-    """
-    if val is None:
-        return None
-    if isinstance(val, list):
-        return ",".join(val) if val else None
-    return val
-
-
 def without_nulls(params: Dict[str, Union[T, None]]) -> Dict[str, T]:
     """
     Filter out `None` values from params
@@ -1370,9 +1359,11 @@ class Client:
         device_id: Optional[str] = None,
         device_name: Optional[str] = None,
         project_id: Optional[str] = None,
-        key: Optional[Union[str, List[str]]] = None,
+        query: Optional[str] = None,
         start: Optional[datetime.datetime] = None,
         end: Optional[datetime.datetime] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ):
@@ -1384,9 +1375,11 @@ class Client:
         device_name: The name of the device to retrieve time intervals from.
             Use this or device_id.
         project_id: Project associated with the device. Required for multi-project organizations.
-        key: Optional property key or keys to filter by.
+        query: Optional query string to filter device property history.
         start: Optionally include intervals active at or after this time.
         end: Optionally include intervals active before this time.
+        sort_by: Optionally sort records by this field name.
+        sort_order: Optionally specify the sort order, either "asc" or "desc".
         limit: Optionally limit the number of time intervals returned.
         offset: Optionally offset the time intervals by this many intervals.
         """
@@ -1394,9 +1387,11 @@ class Client:
 
         params = {
             "projectId": project_id,
-            "key": comma_separated_query_param(key),
+            "query": query,
             "start": start.astimezone().isoformat() if start else None,
             "end": end.astimezone().isoformat() if end else None,
+            "sortBy": camelize(sort_by),
+            "sortOrder": sort_order,
             "limit": limit,
             "offset": offset,
         }

--- a/tests/test_device_custom_property_time_interval.py
+++ b/tests/test_device_custom_property_time_interval.py
@@ -73,21 +73,25 @@ def test_get_device_custom_property_time_intervals_uses_path_selector_only():
     client.get_device_custom_property_time_intervals(
         device_name=device_name,
         project_id="project-id",
-        key="env",
+        query='env:"production fleet"',
+        sort_by="start",
+        sort_order="desc",
         limit=5,
         offset=10,
     )
 
     assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
-        "key": ["env"],
+        "query": ['env:"production fleet"'],
         "limit": ["5"],
         "offset": ["10"],
         "projectId": ["project-id"],
+        "sortBy": ["start"],
+        "sortOrder": ["desc"],
     }
 
 
 @responses.activate
-def test_get_device_custom_property_time_intervals_supports_multiple_keys():
+def test_get_device_custom_property_time_intervals_camelizes_sort_by():
     responses.add(
         responses.GET,
         api_url("/v1/devices/device-id/property-time-intervals"),
@@ -98,12 +102,12 @@ def test_get_device_custom_property_time_intervals_supports_multiple_keys():
     client.get_device_custom_property_time_intervals(
         device_id="device-id",
         project_id="project-id",
-        key=["env", "region"],
+        sort_by="start_time",
     )
 
     assert parse_qs(urlparse(responses.calls[0].request.url).query) == {
-        "key": ["env,region"],
         "projectId": ["project-id"],
+        "sortBy": ["startTime"],
     }
 
 


### PR DESCRIPTION
### Changelog

Revise device property history time interval list to use query instead of key, accept sortBy, sortOrder

### Docs

None

### Description

We had a late revision to the interface for the upcoming device property history time interval. The old interface provided a simple key filter. We've revised that to take the standard query syntax. Also we now support sorting.

### Testing

<img width="763" height="616" alt="Screenshot 2026-03-31 at 2 13 03 PM" src="https://github.com/user-attachments/assets/c535c100-1d83-4e19-be3a-39fb9d7059a4" />

Another custom test script to simulate use
